### PR TITLE
Added the command /odc add that added the current item as the target for it's oreDictionary.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,14 +17,36 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.1"
-group= "com.mattdahepic.hotkeyoredictconv" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "hotkeyoredictconv"
+ext {
+	//Import config file thanks to pahimar :D
+	ext.configFile = file "buildconfig.properties"
+
+}
+
+configFile.withReader {
+    // read config. it shall from now on be referenced as simply config or as project.config
+    def prop = new Properties()
+    prop.load(it)
+    ext.config = new ConfigSlurper().parse prop
+}
+
+if ("${System.env.CI}" == "true"){
+  version = config.mod_version + "-" + "${System.env.BUILD_NUMBER}"
+} else {
+  version = config.mod_version
+}
 
 minecraft {
-    version = "1.7.10-10.13.2.1264"
+    version = config.minecraft_version + "-" + config.forge_version
+
+	replaceIn "OreDictConv.java"
+	replace "@VERSION@", project.version
+
     runDir = "eclipse"
 }
+
+group= "com.mattdahepic.hotkeyoredictconv" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = "HotkeyOredictConv-"+minecraft.version
 
 dependencies {
     // you may put jars on which you depend on in ./libs

--- a/buildconfig.properties
+++ b/buildconfig.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.7.10
+forge_version=10.13.4.1448-1.7.10
+mod_version=1.2.0

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/OreDictConv.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/OreDictConv.java
@@ -1,35 +1,37 @@
 package com.mattdahepic.hotkeyoredictconv;
 
+import net.minecraftforge.oredict.OreDictionary;
+
 import com.mattdahepic.hotkeyoredictconv.command.CommandConfig;
 import com.mattdahepic.hotkeyoredictconv.config.Config;
 import com.mattdahepic.hotkeyoredictconv.network.PacketHandler;
+
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.event.FMLServerStartedEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
-import net.minecraftforge.common.config.Configuration;
 
-@Mod(modid = OreDictConv.MODID,name = OreDictConv.NAME,version = OreDictConv.VERSION)
+@Mod(modid = OreDictConv.MODID,name = OreDictConv.NAME,version = OreDictConv.VERSION, guiFactory = "com.mattdahepic.hotkeyoredictconv.config.GuiFactory")
 public class OreDictConv {
     @Mod.Instance("hotkeyoredictconv")
     public static OreDictConv instance;
 
     public static final String MODID = "hotkeyoredictconv";
     public static final String NAME = "Hotkey Ore Dictionary Converter";
-    public static final String VERSION = "1.1";
+    public static final String VERSION = "@VERSION@";
 
     @SidedProxy(clientSide = "com.mattdahepic.hotkeyoredictconv.client.ClientProxy",serverSide = "com.mattdahepic.hotkeyoredictconv.CommonProxy")
     public static CommonProxy proxy;
-
-    public static Configuration configFile;
 
     @Mod.EventHandler
     public void preInit (FMLPreInitializationEvent event) {
         FMLCommonHandler.instance().bus().register(instance);
         Config.load(event);
+        FMLCommonHandler.instance().bus().register(new Config());
     }
     @Mod.EventHandler
     public void init (FMLInitializationEvent event) {
@@ -44,4 +46,10 @@ public class OreDictConv {
     public void serverStarting (FMLServerStartingEvent event) {
         event.registerServerCommand(new CommandConfig());
     }
+
+    @Mod.EventHandler
+    public void serverStarted (FMLServerStartedEvent event) {
+    	OreDictionary.rebakeMap(); // UGLY FIX for Metallurgy items not returning there OreDictionery. Probably a forge or Metallurgy bug.
+    }
+
 }

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/command/Add.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/command/Add.java
@@ -1,0 +1,38 @@
+package com.mattdahepic.hotkeyoredictconv.command;
+
+import net.minecraft.command.ICommandSender;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.oredict.OreDictionary;
+
+import com.mattdahepic.hotkeyoredictconv.config.Config;
+
+public class Add {
+    private Add () {}
+    public static void add(ICommandSender commandSender, ItemStack item) {
+        int[] oreDictEntryNumbers = OreDictionary.getOreIDs(item);
+        String[] oreDictEntryNames = new String[oreDictEntryNumbers.length];
+        for (int i = 0; i < oreDictEntryNumbers.length; i++) { //add names to array
+            oreDictEntryNames[i] = OreDictionary.getOreName(oreDictEntryNumbers[i]);
+        }
+        if (oreDictEntryNumbers.length==1) {
+        	if (Config.isValidOreName(oreDictEntryNames[0])) {
+	        	if (Config.oreMap.containsKey(oreDictEntryNames[0])) {
+	               	commandSender.addChatMessage(new ChatComponentText("Changed to default item for Ore Dictionary " + oreDictEntryNames[0]));
+	            } else {
+	            	commandSender.addChatMessage(new ChatComponentText("Set to default item for Ore Dictionary " + oreDictEntryNames[0]));
+	            }
+	        	Config.oreMap.put(oreDictEntryNames[0], Item.itemRegistry.getNameForObject(item.getItem()) + ";" + item.getItemDamage());
+	        	Config.saveConfig();
+        	} else {
+        		commandSender.addChatMessage(new ChatComponentText("Ore Dictionary " + oreDictEntryNames[0] + " is not allowed!"));
+        	}
+        	
+        } else if (oreDictEntryNumbers.length>1) {
+	        commandSender.addChatMessage(new ChatComponentText("Can only add items that have ONE Ore dictionary name!"));
+        } else {
+        	commandSender.addChatMessage(new ChatComponentText("This item does not have an Ore dictionary name!"));
+        }
+    }
+}

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/command/CommandConfig.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/command/CommandConfig.java
@@ -11,9 +11,10 @@ import net.minecraft.util.EnumChatFormatting;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings({ "unchecked", "rawtypes" })
 public class CommandConfig implements ICommand {
-    private List aliases, tabCompletionOptions;
-    public CommandConfig () {
+	private List aliases, tabCompletionOptions;
+	public CommandConfig () {
         this.aliases = new ArrayList();
         this.aliases.add("odc");
         this.tabCompletionOptions = new ArrayList();
@@ -21,6 +22,7 @@ public class CommandConfig implements ICommand {
         this.tabCompletionOptions.add("dump");
         this.tabCompletionOptions.add("find");
         this.tabCompletionOptions.add("help");
+        this.tabCompletionOptions.add("add");
     }
     @Override
     public int compareTo (Object arg0) {
@@ -40,7 +42,6 @@ public class CommandConfig implements ICommand {
     }
     @Override
     public void processCommand (ICommandSender iCommandSender, String[] inputString) {
-        ChatComponentText returnText = new ChatComponentText("");
         if (inputString.length == 0) { // no input command
             iCommandSender.addChatMessage(new ChatComponentText("Use \"/odc help\" for useage help."));
             return;
@@ -52,6 +53,14 @@ public class CommandConfig implements ICommand {
             if (inputString[0].equalsIgnoreCase("detect")) {
                 if (item != null) {
                     Detect.detect(iCommandSender,item);
+                    return;
+                } else {
+                    iCommandSender.addChatMessage(new ChatComponentText("You\'re not holding an item!"));
+                    return;
+                }
+            } else if (inputString[0].equalsIgnoreCase("add")) {
+                if (item != null) {
+                    Add.add(iCommandSender,item);
                     return;
                 } else {
                     iCommandSender.addChatMessage(new ChatComponentText("You\'re not holding an item!"));
@@ -69,6 +78,7 @@ public class CommandConfig implements ICommand {
                 return;
             } else if (inputString[0].equalsIgnoreCase("help")) {
                 iCommandSender.addChatMessage(new ChatComponentText("To get the ore dictionary entries of the item currently held, use \"/odc detect\"."));
+                iCommandSender.addChatMessage(new ChatComponentText("To add the item currently held as the default for it's ore dictinary, use \"/odc add\"."));
                 iCommandSender.addChatMessage(new ChatComponentText("To dump all ore dictionary entries to the chat and log, use \"/odc dump\"."));
                 iCommandSender.addChatMessage(new ChatComponentText("To find all items listed as the specified Ore Dictionary name, use \"/odc find <oreDictName>\"."));
                 return;
@@ -86,7 +96,7 @@ public class CommandConfig implements ICommand {
         }
         return false;
     }
-    @Override
+	@Override
     public List addTabCompletionOptions(ICommandSender iCommandSender, String[] inputString) {
         return this.tabCompletionOptions;
     }

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/command/Detect.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/command/Detect.java
@@ -14,7 +14,7 @@ public class Detect {
         for (int i = 0; i < oreDictEntryNumbers.length; i++) { //add names to array
             oreDictEntryNames[i] = OreDictionary.getOreName(oreDictEntryNumbers[i]);
         }
-        commandSender.addChatMessage(new ChatComponentText("Ore dictionary names for item \"" + Item.itemRegistry.getNameForObject(item.getItem()) + "|" + item.getItemDamage() + "\" are:"));
+        commandSender.addChatMessage(new ChatComponentText("Ore dictionary names for item \"" + Item.itemRegistry.getNameForObject(item.getItem()) + ";" + item.getItemDamage() + "\" are:"));
         for (int i = 0; i < oreDictEntryNames.length; i++) { //print names
             commandSender.addChatMessage(new ChatComponentText(oreDictEntryNames[i]));
         }

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/command/DumpOreDict.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/command/DumpOreDict.java
@@ -1,6 +1,10 @@
 package com.mattdahepic.hotkeyoredictconv.command;
 
+import java.util.ArrayList;
+
 import net.minecraft.command.ICommandSender;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -11,6 +15,12 @@ public class DumpOreDict {
         commandSender.addChatMessage(new ChatComponentText("Dumping all Ore Dictionary entries..."));
         for (int i = 0; i < oreDictNames.length; i++) {
             commandSender.addChatMessage(new ChatComponentText(oreDictNames[i]));
+            ArrayList<ItemStack> itemsUnderOreDict = OreDictionary.getOres(oreDictNames[i]);
+            if (!itemsUnderOreDict.isEmpty()) {
+                for (int j = 0; j < itemsUnderOreDict.size(); j++) {
+                    commandSender.addChatMessage(new ChatComponentText("  " + Item.itemRegistry.getNameForObject(itemsUnderOreDict.get(j).getItem()) + ";" + itemsUnderOreDict.get(j).getItemDamage()));
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/command/Find.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/command/Find.java
@@ -14,7 +14,7 @@ public class Find {
         if (!itemsUnderOreDict.isEmpty()) {
             commandSender.addChatMessage(new ChatComponentText("Ore names under entry " + oreDictName + " are:"));
             for (int i = 0; i < itemsUnderOreDict.size(); i++) {
-                commandSender.addChatMessage(new ChatComponentText(Item.itemRegistry.getNameForObject(itemsUnderOreDict.get(i).getItem()) + "|" + itemsUnderOreDict.get(i).getItemDamage()));
+                commandSender.addChatMessage(new ChatComponentText(Item.itemRegistry.getNameForObject(itemsUnderOreDict.get(i).getItem()) + ";" + itemsUnderOreDict.get(i).getItemDamage()));
             }
             return;
         } else {

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/config/Config.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/config/Config.java
@@ -1,13 +1,22 @@
 package com.mattdahepic.hotkeyoredictconv.config;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
 import com.mattdahepic.hotkeyoredictconv.OreDictConv;
 import com.mattdahepic.hotkeyoredictconv.log.Log;
+
 import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
 
 /*
 Sample Config:
@@ -16,73 +25,149 @@ String List:
  */
 
 public class Config {
-    public static String[] oreValues = {"oreIron=minecraft:iron_ore|0","oreGold=minecraft:gold_ore|0"};
-    public static Configuration config;
+    static Configuration config;
+    public static HashMap<String, String> oreMap = new HashMap<String, String>();
+    public static Boolean debug = false;
+    private static String[] oreValues = {"oreIron=minecraft:iron_ore;0","oreGold=minecraft:gold_ore;0"};
+    private static Property oreValuesProp;
+    private static List<Pattern> whitelist;
+    private static List<Pattern> blacklist;
 
-    public static void load (FMLPreInitializationEvent event) {
-        OreDictConv.configFile = new Configuration(event.getSuggestedConfigurationFile());
+    private static final String REGEX_COMMENT = "Supports multiple expressions separated by commas.\n"
+        + "Uses Java's Pattern class regex syntax. See the following page for more info about Pattern regex syntax:\n"
+        + "http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html";
+    
+    private static final String WHITELIST_COMMENT = "Only ore dictionary names that match any of these regexes can be added. " + REGEX_COMMENT;
+    private static final String BLACKLIST_COMMENT = "Ore dictionary names that match any of these regexes can not be added. " + REGEX_COMMENT;
+
+    public static void load(FMLPreInitializationEvent event) {
+        config = new Configuration(event.getSuggestedConfigurationFile());
         syncConfig();
     }
 
-    public static void syncConfig () {
+    public static void syncConfig() {
         try {
-            Config.processConfig(OreDictConv.configFile);
+            Config.loadConfig(config);
         } catch (Exception e) {
             Log.error("Error loading config file!");
             e.printStackTrace();
         } finally {
-            if (OreDictConv.configFile.hasChanged()) {
-                Log.info("Saving config file!");
-                OreDictConv.configFile.save();
+            if (config.hasChanged()) {
+            	if (debug)
+            		Log.info("Saving config file!");
+                config.save();
             }
         }
     }
     @SubscribeEvent
-    public void OnConfigChanged (ConfigChangedEvent.OnConfigChangedEvent event) {
+    public void OnConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
         if (event.modID.equals(OreDictConv.MODID)) {
-            Log.info("Updating config!");
+        	if (debug)
+        		Log.info("Updating config!");
             syncConfig();
         }
     }
 
-    public static void processConfig (Configuration config) {
-        oreValues = config.getStringList("oreValues",Configuration.CATEGORY_GENERAL,oreValues,"Place your ores here in format \"oreDictName=modid:itemName|metaValue\". Use the ingame command /odc to get the ore dict names.");
+	public static void loadConfig(Configuration config) {
+
+		debug = config.get(Configuration.CATEGORY_GENERAL, "debug", false, "Enable debug output in the log").getBoolean(); // Load this first
+		
+		String whitelist_line = config.get(Configuration.CATEGORY_GENERAL, "whitelist", "^ore.*,^ingot.*,^dust.*,^block.*,^nugget.*",WHITELIST_COMMENT).getString();
+	    String blacklist_line = config.get(Configuration.CATEGORY_GENERAL, "blacklist", "",BLACKLIST_COMMENT).getString();
+	    whitelist = CompilePatterns(whitelist_line);
+	    blacklist = CompilePatterns(blacklist_line);
+	    
+		oreValuesProp = config.get(Configuration.CATEGORY_GENERAL, "oreValues", oreValues, "Place your ores here in format \"oreDictName=modid:itemName;metaValue\". Use the ingame command /odc to get the ore dict names.");
+        String[] tempArray = oreValuesProp.getStringList();
+        oreMap = new HashMap<String, String>();
+        for (int i=0; i<tempArray.length; i++) {
+        	String parts[] = tempArray[i].split("=", 2);
+        	if (parts.length==2) {
+        		if (debug)
+        			Log.info("load config: "+parts[0]+"="+parts[1]);
+        		if (isValidOreName(parts[0])) {
+        			oreMap.put(parts[0], parts[1]);
+        		} else {
+        			Log.error("Illeagal oreName in config ignored. "+parts[0]);
+        		}
+        		
+        	} else {
+        		Log.error("Invalid config entry \""+tempArray[i]+"\"!");
+        	}
+        }
     }
 
-    public static ItemStack getItem (String oreDictName) {
-        for (int i = 0; i < oreValues.length; i++) { //for each entry in the config
-            if (oreValues[i].startsWith(oreDictName + "=")) { //if the entry starts with the same value
-                if (oreValues[i].length() > oreDictName.length()+1) { //and it presumably includes an entry
-                    String temp = oreValues[i];
-                    //get the data value
-                    int colonLocation = 0;
-                    String name = null;
-                    for (int j = 0; j < temp.length(); j++) { //get where data value divider is
-                        if (temp.charAt(j) == '|') {
-                            colonLocation = j;
-                            name = temp.substring(oreDictName.length()+1,colonLocation); //get item name if data value exists
-                        }
-                    }
-                    if (name == null) {
-                        return null;
-                    }
-                    Item tempItem = (Item) Item.itemRegistry.getObject(name); //get actual item from name
-                    int dataValue;
-                    try {
-                        dataValue = Integer.parseInt(temp.substring(colonLocation+1,temp.length())); //see if the entry ACTUALLY ends with a number
-                    } catch (Exception e) {
-                        dataValue = 0;
-                    }
-                    if (tempItem != null) { //is item illegal?
-                        return new ItemStack(tempItem,1,dataValue);
-                    } else {
-                        Log.error("Config incorrectly set convertable item for entry " + oreDictName + "! FIX IT.");
-                        return null;
-                    }
-                }
+    public static void saveConfig() {
+    	try {
+    		String [] tempArray = new String[oreMap.size()];
+    		Iterator<String> it = oreMap.keySet().iterator();
+    		int i = 0;
+    		while (it.hasNext()) {
+    			String k = it.next();
+    			tempArray[i++] = k + "=" + oreMap.get(k);
+    		}
+	        oreValuesProp.set(tempArray);
+        } catch (Exception e) {
+            Log.error("Error saving config file!");
+            e.printStackTrace();
+        } finally {
+            if (config.hasChanged()) {
+            	config.save();
             }
         }
-        //no entry matched
-        return null;
+    }
+
+    static private List<Pattern> CompilePatterns(String line) {
+	    List<Pattern> list = new ArrayList<Pattern>();
+	    String[] tokens = line.split(",");
+	    for(String t: tokens) {
+		    t = t.trim();
+		    if(t == null || t.isEmpty()) {
+		    	continue;
+		    }
+		    try {
+		    	list.add(Pattern.compile(t));
+		    } catch(PatternSyntaxException e) {
+		    	Log.warn("Pattern '" + t + "' has invalid syntax.");
+		    }
+	    }
+	    return list;
+    }
+    
+    static private boolean MatchesAnyPattern(String str, List<Pattern> patterns) {
+      for(Pattern p:patterns) {
+        if(p.matcher(str).matches()) {
+          return true;
+        }
+      }
+      return false;
+    }
+    
+    public static boolean isValidOreName(String oreName) {
+    	return MatchesAnyPattern(oreName, whitelist) && !MatchesAnyPattern(oreName, blacklist);
+    }
+
+    public static ItemStack getItem(String oreDictName) {
+    	return getItem(oreDictName, 1);
+    }
+    
+    public static ItemStack getItem(String oreDictName, int num) {
+    	if (!oreMap.containsKey(oreDictName))
+    		return null;
+    	String[] parts = oreMap.get(oreDictName).split(";", 2);
+    	int meta = 0;
+    	if ( parts.length > 1 ) {
+    		try {
+    			meta = Integer.parseInt(parts[1]);
+    		} catch (Exception e) {
+    		}
+    	}
+    	Item tempItem = (Item) Item.itemRegistry.getObject(parts[0]);
+    	if ( tempItem != null ) {
+    		return new ItemStack(tempItem, num, meta);
+        } else {
+            Log.error("Config incorrectly set convertable item for entry " + oreDictName + "! FIX IT.");
+        }
+    	return null;
     }
 }

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/config/ConfigGui.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/config/ConfigGui.java
@@ -1,0 +1,24 @@
+package com.mattdahepic.hotkeyoredictconv.config;
+
+
+import com.mattdahepic.hotkeyoredictconv.OreDictConv;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.common.config.ConfigElement;
+import net.minecraftforge.common.config.Configuration;
+import cpw.mods.fml.client.config.GuiConfig;
+
+public class ConfigGui extends GuiConfig {
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public ConfigGui(GuiScreen gui)
+	{
+		super(gui,
+				new ConfigElement(Config.config.getCategory(Configuration.CATEGORY_GENERAL)).getChildElements(),
+				OreDictConv.MODID,
+				false,
+				true,
+				GuiConfig.getAbridgedConfigPath(Config.config.toString()));
+		
+	}
+	
+}

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/config/GuiFactory.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/config/GuiFactory.java
@@ -1,0 +1,35 @@
+package com.mattdahepic.hotkeyoredictconv.config;
+
+import java.util.Set;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import cpw.mods.fml.client.IModGuiFactory;
+
+public class GuiFactory implements IModGuiFactory {
+
+	@Override
+	public void initialize(Minecraft minecraftInstance) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public Class<? extends GuiScreen> mainConfigGuiClass() {
+		return ConfigGui.class;
+	}
+
+	@Override
+	public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public RuntimeOptionGuiHandler getHandlerFor(
+			RuntimeOptionCategoryElement element) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/input/KeyHandler.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/input/KeyHandler.java
@@ -1,8 +1,10 @@
 package com.mattdahepic.hotkeyoredictconv.input;
 
+import com.mattdahepic.hotkeyoredictconv.config.Config;
 import com.mattdahepic.hotkeyoredictconv.log.Log;
 import com.mattdahepic.hotkeyoredictconv.network.ODCPacket;
 import com.mattdahepic.hotkeyoredictconv.network.PacketHandler;
+
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -10,6 +12,7 @@ import cpw.mods.fml.common.gameevent.InputEvent;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.common.MinecraftForge;
+
 import org.lwjgl.input.Keyboard;
 
 public class KeyHandler {
@@ -32,7 +35,8 @@ public class KeyHandler {
     }
     private void handleConvert () {
         if (convertKey.getIsKeyPressed()) {
-            Log.playerChat("Beginning conversion!");
+        	if (Config.debug)
+        		Log.playerChat("Beginning conversion!");
             IMessage msg = new ODCPacket.ODCMessage();
             PacketHandler.net.sendToServer(msg);
         }

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/network/ODCPacket.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/network/ODCPacket.java
@@ -2,7 +2,11 @@ package com.mattdahepic.hotkeyoredictconv.network;
 
 //props to diesieben07 on #minecraftforge irc
 
+import net.minecraft.util.ChatComponentText;
+
+import com.mattdahepic.hotkeyoredictconv.config.Config;
 import com.mattdahepic.hotkeyoredictconv.convert.Convert;
+
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/mattdahepic/hotkeyoredictconv/network/PacketHandler.java
+++ b/src/main/java/com/mattdahepic/hotkeyoredictconv/network/PacketHandler.java
@@ -3,6 +3,7 @@ package com.mattdahepic.hotkeyoredictconv.network;
 //props to CatDany: https://gist.github.com/CatDany/4a3df7fcb3c8270cf70b
 
 import com.mattdahepic.hotkeyoredictconv.OreDictConv;
+
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import cpw.mods.fml.relauncher.Side;
@@ -14,7 +15,8 @@ public class PacketHandler {
         registerMessage(ODCPacket.class,ODCPacket.ODCMessage.class);
     }
     private static int nextPacketId = 0;
-    private static void registerMessage(Class packet, Class message) {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+	private static void registerMessage(Class packet, Class message) {
         net.registerMessage(packet,message,nextPacketId, Side.CLIENT);
         net.registerMessage(packet,message,nextPacketId,Side.SERVER);
         nextPacketId++;

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "hotkeyoredictconv",
   "name": "Hotkey Ore Dictionary Converter",
   "description": "Converts specified ore dictionary items on keybinding.",
-  "version": "1.1",
+  "version": "${version}",
   "mcversion": "${mcversion}",
   "url": "",
   "updateUrl": "",


### PR DESCRIPTION
Added the command /odc add that added the current item as the target for
it's oreDictionary. The item can only be in one oreDictionary.
Changed from oreValue array to oreMap hashMap to speed up conversion.
Implemented WhiteList and BlackList for oreDictionary names. Default
allows ore*, ingot*, dust*, nugget* and block*
Moved mod and forge version to buildconfig.properties
Added "fix" for Metallurgy items not returning there oreDictionary name.
Changed separator for metadata in config from | to ; because | does not
work with Buildcraft that use | in it's mod name.
Made config editable in the client. (Recommend using InGameModConfigs to
also be able to edit config while in a world.) No need to restart
Minecraft for config changes to take effect.
Updated to use forge 1448
There is a bug when adding items with NEI. (If you move the item added
by NEI from the hotbar to the main inventory the server thinks the item
exists in both places. But since this bug only shows it self when you
cheat in items it's not that major).